### PR TITLE
Update all flags with readable and searchable names

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Web Development Conferences 2018
 
 A list of Web & JavaScript related conferences happening in 2018.
-Please send in a PR if you want to add a new event or fix/enhance the info given for existing ones. 
+Please send in a PR if you want to add a new event or fix/enhance the info given for existing ones.
 Thank you 🙏
 
 > If you want to discover conferences, host events or want to let others know that you´re attending, check out: [Colloq](https://colloq.io/)
@@ -10,150 +10,150 @@ Thank you 🙏
 
 | Event | Location | Date | Topic | CFP | CoC |
 |-------|:--------:|:----:|:-----:|:---:|-----|
-| [Front - UX & Product Management Bootcamp 2018](https://www.frontutah.com/) | Park City, 🇺🇸 | January 4-5 | Frontend, UX | ❌ | [✅](https://www.frontutah.com/code-of-conduct) |
-| [CodeMash 2018](http://www.codemash.org/) | Sandusky 🇺🇸 | January 9-12 |  Java, .NET, Ruby, Python, PHP | ❌ | [✅](http://www.codemash.org/codemash-code-conduct/) |
-| [Accessibility Club](https://colloq.io/events/accessibility-club/2018/munich/1) | Munich 🇩🇪 | January 15 |  Frontend, A11y | ❌ | [✅](https://beyondtellerrand.com/code-of-conduct) |
-| [beyond tellerrand // MUNICH 2018](https://beyondtellerrand.com/) | Munich 🇩🇪 | January 15-17 |  Frontend, UX, Creativity | ❌ | [✅](https://beyondtellerrand.com/code-of-conduct) |
-| [NDC London](https://ndc-london.com/) | London 🇬🇧 | January 15-19 |  Frontend, Backend | ❌ | [✅](https://ndc-london.com/page/code-of-conduct) |
-| [ReactFoo](https://reactfoo.in/2018-pune/) | Pune 🇮🇳 | January 19-20 |  JavaScript, React | [✅](https://reactfoo.talkfunnel.com/2017-pune/) | [✅](https://reactfoo.in/code-of-conduct) |
-| [Script 18](https://scriptconf.org/) | Linz 🇦🇹 | January 19 | JavaScript | ❌ | [✅](https://scriptconf.org/code-of-conduct/) |
+| [Front - UX & Product Management Bootcamp 2018](https://www.frontutah.com/) | Park City, USA 🇺🇸 | January 4-5 | Frontend, UX | ❌ | [✅](https://www.frontutah.com/code-of-conduct) |
+| [CodeMash 2018](http://www.codemash.org/) | Sandusky, USA 🇺🇸 | January 9-12 |  Java, .NET, Ruby, Python, PHP | ❌ | [✅](http://www.codemash.org/codemash-code-conduct/) |
+| [Accessibility Club](https://colloq.io/events/accessibility-club/2018/munich/1) | Munich, Germany 🇩🇪  | January 15 |  Frontend, A11y | ❌ | [✅](https://beyondtellerrand.com/code-of-conduct) |
+| [beyond tellerrand // MUNICH 2018](https://beyondtellerrand.com/) | Munich, Germany 🇩🇪  | January 15-17 |  Frontend, UX, Creativity | ❌ | [✅](https://beyondtellerrand.com/code-of-conduct) |
+| [NDC London](https://ndc-london.com/) | London, UK 🇬🇧 | January 15-19 |  Frontend, Backend | ❌ | [✅](https://ndc-london.com/page/code-of-conduct) |
+| [ReactFoo](https://reactfoo.in/2018-pune/) | Pune, India 🇮🇳 | January 19-20 |  JavaScript, React | [✅](https://reactfoo.talkfunnel.com/2017-pune/) | [✅](https://reactfoo.in/code-of-conduct) |
+| [Script 18](https://scriptconf.org/) | Linz, Austria 🇦🇹 | January 19 | JavaScript | ❌ | [✅](https://scriptconf.org/code-of-conduct/) |
 | [JSConf.Asia 2018](https://2018.jsconf.asia/) | Singapore 🇸🇬 | January 25-27 | JavaScript, CSS, Web | [✅](https://contribute.jsconf.asia/) | [✅](https://2016.devfest.asia/code-of-conduct/) |
-| [AgentConf](https://www.agent.sh/) | Dornbirn 🇦🇹 | January 25-28 | JavaScript, Web | ❌ | [✅](https://www.agent.sh/coc) |
+| [AgentConf](https://www.agent.sh/) | Dornbirn, Austria 🇦🇹 | January 25-28 | JavaScript, Web | ❌ | [✅](https://www.agent.sh/coc) |
 
 ## February
 
 | Event | Location | Date | Topic | CFP | CoC |
 |-------|:--------:|:----:|:-----:|:---:|-----|
-| [ng-europe](https://ngeurope.org/) | Paris 🇫🇷 | February 1-2 | JavaScript, Angular | ❌ | [✅](http://confcodeofconduct.com/) |
-| [Pacific NW Drupal Summit](https://pnwdrupalsummit.org/2018/) | Portland 🇺🇸 | February 3-4 | Drupal, PHP, Symfony, Frontend, Being Human | ❌ | [✅](https://pnwdrupalsummit.org/2018/code-conduct) |
-| [JFokus](https://www.jfokus.se/jfokus/) | Stockholm 🇸🇪 | February 5-7 | Java, JavaScript | ❌ | [✅](http://confcodeofconduct.com/) |
-| [Smashing Conf London](https://smashingconf.com/) | London 🇬🇧 | February 7-8 | Frontend, Web, HTML, CSS, JavaScript | ❌ | [✅](https://smashingconf.com/codeofconduct) |
+| [ng-europe](https://ngeurope.org/) | Paris, France 🇫🇷 | February 1-2 | JavaScript, Angular | ❌ | [✅](http://confcodeofconduct.com/) |
+| [Pacific NW Drupal Summit](https://pnwdrupalsummit.org/2018/) | Portland, USA 🇺🇸 | February 3-4 | Drupal, PHP, Symfony, Frontend, Being Human | ❌ | [✅](https://pnwdrupalsummit.org/2018/code-conduct) |
+| [JFokus](https://www.jfokus.se/jfokus/) | Stockholm, Sweden 🇸🇪 | February 5-7 | Java, JavaScript | ❌ | [✅](http://confcodeofconduct.com/) |
+| [Smashing Conf London](https://smashingconf.com/) | London, UK 🇬🇧 | February 7-8 | Frontend, Web, HTML, CSS, JavaScript | ❌ | [✅](https://smashingconf.com/codeofconduct) |
 | [The Rolling Scopes Conference](https://2018.conf.rollingscopes.com/) | Minsk 🇧🇾 | February 10-11 | Frontend, Web, HTML, CSS, JavaScript | ❌ | [✅](https://2018.conf.rollingscopes.com/codeofconduct.html) |
 | [SustainableUX](http://sustainableux.com/) | Online 🌐 | February 15 | UX, Design | ❌ | [✅](http://sustainableux.com/codeofconduct/) |
-| [Webstock](https://www.webstock.org.nz/18/) | Wellington 🇳🇿 | February 12-16 | Frontend, Web, HTML, CSS, JavaScript | ❌ | [✅](https://www.webstock.org.nz/18/code-of-conduct/) |
-| [Front Fest](http://frontfest.es/) | Madrid 🇪🇸 | February 17 | Frontend, Web, HTML, CSS, JavaScript | ❌ | [✅](http://frontfest.es/codigo-conducta.html#team) |
-| [FITC Amsterdam](http://fitc.ca/event/am18/) | Amsterdam 🇳🇱 | February 21-23 | Design, Development, Inspiration | ❌ | [✅](http://fitc.ca/code-of-conduct/) |
-| [Assert(JS)](https://www.assertjs.com/) | San Antonio 🇺🇸 | February 22 | JavaScript, Testing | ❌ | [✅](https://www.assertjs.com/code-of-conduct) |
+| [Webstock](https://www.webstock.org.nz/18/) | Wellington, New Zealand 🇳🇿 | February 12-16 | Frontend, Web, HTML, CSS, JavaScript | ❌ | [✅](https://www.webstock.org.nz/18/code-of-conduct/) |
+| [Front Fest](http://frontfest.es/) | Madrid, Spain 🇪🇸   | February 17 | Frontend, Web, HTML, CSS, JavaScript | ❌ | [✅](http://frontfest.es/codigo-conducta.html#team) |
+| [FITC Amsterdam](http://fitc.ca/event/am18/) | Amsterdam, The Netherlands 🇳🇱 | February 21-23 | Design, Development, Inspiration | ❌ | [✅](http://fitc.ca/code-of-conduct/) |
+| [Assert(JS)](https://www.assertjs.com/) | San Antonio, USA 🇺🇸 | February 22 | JavaScript, Testing | ❌ | [✅](https://www.assertjs.com/code-of-conduct) |
 
 ## March
 
 | Event | Location | Date | Topic | CFP | CoC |
 |-------|:--------:|:----:|:-----:|:---:|-----|
-| [JSConf Iceland](https://2018.jsconf.is/) | Rejkjavik 🇮🇸 | March 1-2 | JavaScript | ❌ | [✅](http://confcodeofconduct.com/) |
-| [NGVikings](https://ngvikings.org) | Helsinki 🇫🇮 | March 1-2 | JavaScript, Angular | [✅ ](https://docs.google.com/forms/d/e/1FAIpQLSePYV6ek4ixXuGxmnImQnhBRaQ7g2tmmhdOOo1dBS2_R1iK0Q/viewform) | [✅](https://ngvikings.org/faq/) |
-| [Concat](https://2018.conc.at/) | Salzburg 🇦🇹 | March 3 | Web, UX | ❌ | [✅](https://2018.conc.at/#coc) |
-| [TOCA ME](http://www.toca-me.com/) | Munich 🇩🇪 | March 3 | Design, Inspiration | ❌ | ❓ |
-| [QCon London](https://qconlondon.com/) | London 🇬🇧  | March 5-7 | Development, Performance, Architecture | [✅](https://qconlondon.com/talk-submissions) | [✅](https://qconlondon.com/code-conduct) |
-| [ReactFest 2018](https://reactfest.com/) | London 🇬🇧  | March 9 | JavaScript, React | [✅ ](https://docs.google.com/forms/d/e/1FAIpQLScACeKKR_21RSDcKUxfsjLd1jCCeq-QHxll78gF99rmQCcljA/viewform) |❓ |
-| [Internet of Things Conference](https://iotcon.de/de/) | Munich 🇩🇪 | March 12-14 | IoT | ❌ | ❓ |
-| [Emberconf](http://emberconf.com/) | Portland 🇺🇸 | March 13-14 | JavaScript, Ember | [✅ ](https://cfp.emberconf.com/events/emberconf-2018)| [✅](http://emberconf.com/code-of-conduct.html) |
-| [UpFrontConf](http://upfrontconf.com/) | Manchester 🇬🇧  | March 16 | Frontend, HTML, CSS, JavaScript | [✅](https://docs.google.com/forms/d/e/1FAIpQLScg8giABm8oKs161VIK8nIpwMt5IXyeL4gcm8DWu_Z-2_d3GQ/viewform) | [✅](http://upfrontconf.com/code-of-conduct/) |
-| [Pipeline Conf](https://pipelineconf.info/) | London 🇬🇧  | March 20 | Architecture, Development, CI/CD | [✅](https://pipelineconf.info/submit-a-proposal/) | [✅](http://pipelineconf.info/pipeline/about/code-of-conduct/) |
-| [CSSConf AU](https://2018.cssconf.com.au/) | Melbourne 🇦🇺 | March 20 | CSS | [✅](https://2018.cssconf.com.au/call-for-speakers) | [✅](https://2018.cssconf.com.au/code-of-conduct) |
-| [JAZZCon](http://jazzcon.tech/) | New Orleans 🇺🇸 | March 21-23 | JavaScript, JS Frameworks, HTML5, CSS3 | [✅](http://jazzcon.tech/#cfp-content) | [✅](http://jazzcon.tech/#inline-content) |
-| [JSConf AU](http://2018.jsconfau.com/) | Melbourne 🇦🇺 | March 21-22 | JavaScript | [✅](http://2018.jsconfau.com/call-for-speakers) | [✅](http://2018.jsconfau.com/code-of-conduct) |
-| [Render Conf](https://2018.render-conf.com/) | Oxford 🇬🇧  | March 23 | JavaScript, HTML, CSS | [✅](https://docs.google.com/forms/d/e/1FAIpQLSe2AI2-tOT8-pHYN_rOtQItuNkJjDf-TjpunwCH6A9F6p8ihw/viewform) | [✅](https://2018.render-conf.com/code-of-conduct) |
-| [VUECONF.us](http://us.vuejs.org/) | New Orleans 🇺🇸 | March 26-28 | JavaScript, Vue | [✅](http://us.vuejs.org/call-for-papers)| [✅](http://us.vuejs.org/codeofconduct) |
-| [#PerfMatters](https://perfmattersconf.com/) | Redwood City 🇺🇸 | March 27-28 | Web, Performance | ❌ | [✅](https://perfmattersconf.com/code/) |
+| [JSConf Iceland](https://2018.jsconf.is/) | Rejkjavik, Iceland 🇮🇸 | March 1-2 | JavaScript | ❌ | [✅](http://confcodeofconduct.com/) |
+| [NGVikings](https://ngvikings.org) | Helsinki, Finland 🇫🇮 | March 1-2 | JavaScript, Angular | [✅ ](https://docs.google.com/forms/d/e/1FAIpQLSePYV6ek4ixXuGxmnImQnhBRaQ7g2tmmhdOOo1dBS2_R1iK0Q/viewform) | [✅](https://ngvikings.org/faq/) |
+| [Concat](https://2018.conc.at/) | Salzburg, Austria 🇦🇹 | March 3 | Web, UX | ❌ | [✅](https://2018.conc.at/#coc) |
+| [TOCA ME](http://www.toca-me.com/) | Munich, Germany 🇩🇪  | March 3 | Design, Inspiration | ❌ | ❓ |
+| [QCon London](https://qconlondon.com/) | London, UK 🇬🇧  | March 5-7 | Development, Performance, Architecture | [✅](https://qconlondon.com/talk-submissions) | [✅](https://qconlondon.com/code-conduct) |
+| [ReactFest 2018](https://reactfest.com/) | London, UK 🇬🇧  | March 9 | JavaScript, React | [✅ ](https://docs.google.com/forms/d/e/1FAIpQLScACeKKR_21RSDcKUxfsjLd1jCCeq-QHxll78gF99rmQCcljA/viewform) |❓ |
+| [Internet of Things Conference](https://iotcon.de/de/) | Munich, Germany 🇩🇪  | March 12-14 | IoT | ❌ | ❓ |
+| [Emberconf](http://emberconf.com/) | Portland, USA 🇺🇸 | March 13-14 | JavaScript, Ember | [✅ ](https://cfp.emberconf.com/events/emberconf-2018)| [✅](http://emberconf.com/code-of-conduct.html) |
+| [UpFrontConf](http://upfrontconf.com/) | Manchester, UK 🇬🇧  | March 16 | Frontend, HTML, CSS, JavaScript | [✅](https://docs.google.com/forms/d/e/1FAIpQLScg8giABm8oKs161VIK8nIpwMt5IXyeL4gcm8DWu_Z-2_d3GQ/viewform) | [✅](http://upfrontconf.com/code-of-conduct/) |
+| [Pipeline Conf](https://pipelineconf.info/) | London, UK 🇬🇧  | March 20 | Architecture, Development, CI/CD | [✅](https://pipelineconf.info/submit-a-proposal/) | [✅](http://pipelineconf.info/pipeline/about/code-of-conduct/) |
+| [CSSConf AU](https://2018.cssconf.com.au/) | Melbourne, Australia 🇦🇺 | March 20 | CSS | [✅](https://2018.cssconf.com.au/call-for-speakers) | [✅](https://2018.cssconf.com.au/code-of-conduct) |
+| [JAZZCon](http://jazzcon.tech/) | New Orleans, USA 🇺🇸 | March 21-23 | JavaScript, JS Frameworks, HTML5, CSS3 | [✅](http://jazzcon.tech/#cfp-content) | [✅](http://jazzcon.tech/#inline-content) |
+| [JSConf AU](http://2018.jsconfau.com/) | Melbourne, Australia 🇦🇺 | March 21-22 | JavaScript | [✅](http://2018.jsconfau.com/call-for-speakers) | [✅](http://2018.jsconfau.com/code-of-conduct) |
+| [Render Conf](https://2018.render-conf.com/) | Oxford, UK 🇬🇧  | March 23 | JavaScript, HTML, CSS | [✅](https://docs.google.com/forms/d/e/1FAIpQLSe2AI2-tOT8-pHYN_rOtQItuNkJjDf-TjpunwCH6A9F6p8ihw/viewform) | [✅](https://2018.render-conf.com/code-of-conduct) |
+| [VUECONF.us](http://us.vuejs.org/) | New Orleans, USA 🇺🇸 | March 26-28 | JavaScript, Vue | [✅](http://us.vuejs.org/call-for-papers)| [✅](http://us.vuejs.org/codeofconduct) |
+| [#PerfMatters](https://perfmattersconf.com/) | Redwood City, USA 🇺🇸 | March 27-28 | Web, Performance | ❌ | [✅](https://perfmattersconf.com/code/) |
 
 ## April
 
 | Event | Location | Date | Topic | CFP | CoC |
 |-------|:--------:|:----:|:-----:|:---:|-----|
-| [ForwardJS](https://forwardjs.com/ottawa) | Ottawa 🇨🇦 | April 3-6 | JavaScript | [✅](https://docs.google.com/forms/d/e/1FAIpQLScUxLsLva4kXTCDtcUgIxqQJnedFcgAsf2kpwI7dB8SV5kwhw/viewform) | [✅](http://confcodeofconduct.com/) |
-| [Webcon](http://webcon.illinois.edu/schedule.shtml) | Illinois 🇺🇸 | April 4-6 | JavaScript, HTML, CSS, Web | [✅](http://webmasters.illinois.edu/#about) | [✅](http://webcon.illinois.edu/code.pdf) |
-| [Frontend NE](https://2018.frontendne.co.uk/) | Newcastle 🇬🇧  | April 5 | JavaScript, HTML, CSS | [✅](https://2018.frontendne.co.uk/call-for-speakers.html) | [✅](https://2018.frontendne.co.uk/code-of-conduct.html) |
-| [Pro Web](https://2018.programming-conference.org) | Nice 🇫🇷 | April 9-12 | Development, Web | [✅](https://2018.programming-conference.org/track/proweb-2018-papers) |❓ |
-| [Web à Québec](http://www.webaquebec.org/en) | Québec 🇨🇦 | April 10-12 | Development, Web | [✅](https://docs.google.com/forms/d/e/1FAIpQLSfBycxEH2ksIK0fnrXYTSZkb2EQSMFHwyTkC1j36NyyVlKNGQ/closedform) | [✅](http://www.webaquebec.org/code-de-conduite) |
-| [International JavaScript Conference](https://javascript-conference.com/) | London 🇬🇧  | April 11-13 | JavaScript | ❌ | [✅](http://confcodeofconduct.com/) |
-| [React Amsterdam](https://react.amsterdam/) | Amsterdam 🇳🇱 | April 13 | JavaScript, React | [✅](https://goo.gl/forms/TXVpj5rIdSPP47bd2) | [✅](http://confcodeofconduct.com/) |
-| [Universal JS Day](https://2018.universaljsday.com/) | Ferrara 🇮🇹 | April 13 | JavaScript | [✅](https://2018.universaljsday.com/#cfp) | ❓ |
-| [UX + DEV Summit](https://uxdsummit.com/) | Fort Lauderdale 🇺🇸 | April 14-16 | Frontend, UX | ✅ | [✅](https://uxdsummit.com/call-for-speakers/) |
-| [Bulgaria Web Summit](https://bulgariawebsummit.com/) | Sofia 🇧🇬 | April 14 | HTML, CSS, JavaScript | ❓ | [✅](https://bulgariawebsummit.com/) |
-| [Smashing Conf San Francisco](https://smashingconf.com/sf-2018/) | San Francisco 🇺🇸 | April 17-18 | Frontend, Web, HTML, CSS, JavaScript | ❌ | [✅](https://smashingconf.com/codeofconduct) |
-| [ng-conf](https://www.ng-conf.org/) | Salt Lake City 🇺🇸 | April 18-20 | JavaScript, AngularJS | [✅](https://goo.gl/forms/ExEPOnDxRRaQtC9C3) | [✅](https://www.ng-conf.org/wp-content/uploads/2017/03/Code-of-Conduct.pdf) |
-| [JSHeroes](https://jsheroes.io/) | Cluj Napoca 🇷🇴 | April 18-20 | JavaScript | [✅](https://docs.google.com/forms/d/e/1FAIpQLSdPSo4Zy_M78PHRVFz90v1_SV3IqRcyhvgK2oCDY6ju6NDWeA/viewform) | [✅](https://jsheroes.io/code-of-conduct) |
-| [DevExperience](http://devexperience.ro/) | Iasi 🇷🇴 | April 19-21 | Development, Architecture | ❌ | ❓ |
-| [React Finland](https://react-finland.fi/) | Helsinki 🇫🇮 | April 24-26 | Development, JavaScript, React, Web | ❌ | [✅](http://berlincodeofconduct.org/) |
-| [FEDC](http://frontenddesignconference.com/) | St. Petersburg 🇺🇸 | April 25-27 | UX, Web, Frontend | ❌ | ❓ |
-| [#devone](https://devone.at/) | Linz 🇦🇹 | April 26 | Development, Architecture, DevOps | ❌ | [✅](https://devone.at/code-of-conduct/) |
-| [UphillConf](http://uphillconf.com/) | Bern 🇨🇭 | April 26-27 | Frontend, JavaScript | ❌ | [✅](https://uphillconf.com/code-of-conduct/) |
+| [ForwardJS](https://forwardjs.com/ottawa) | Ottawa, Canada 🇨🇦 | April 3-6 | JavaScript | [✅](https://docs.google.com/forms/d/e/1FAIpQLScUxLsLva4kXTCDtcUgIxqQJnedFcgAsf2kpwI7dB8SV5kwhw/viewform) | [✅](http://confcodeofconduct.com/) |
+| [Webcon](http://webcon.illinois.edu/schedule.shtml) | Illinois, USA 🇺🇸 | April 4-6 | JavaScript, HTML, CSS, Web | [✅](http://webmasters.illinois.edu/#about) | [✅](http://webcon.illinois.edu/code.pdf) |
+| [Frontend NE](https://2018.frontendne.co.uk/) | Newcastle, UK 🇬🇧  | April 5 | JavaScript, HTML, CSS | [✅](https://2018.frontendne.co.uk/call-for-speakers.html) | [✅](https://2018.frontendne.co.uk/code-of-conduct.html) |
+| [Pro Web](https://2018.programming-conference.org) | Nice, France 🇫🇷 | April 9-12 | Development, Web | [✅](https://2018.programming-conference.org/track/proweb-2018-papers) |❓ |
+| [Web à Québec](http://www.webaquebec.org/en) | Québec, Canada 🇨🇦 | April 10-12 | Development, Web | [✅](https://docs.google.com/forms/d/e/1FAIpQLSfBycxEH2ksIK0fnrXYTSZkb2EQSMFHwyTkC1j36NyyVlKNGQ/closedform) | [✅](http://www.webaquebec.org/code-de-conduite) |
+| [International JavaScript Conference](https://javascript-conference.com/) | London, UK 🇬🇧  | April 11-13 | JavaScript | ❌ | [✅](http://confcodeofconduct.com/) |
+| [React Amsterdam](https://react.amsterdam/) | Amsterdam, The Netherlands 🇳🇱 | April 13 | JavaScript, React | [✅](https://goo.gl/forms/TXVpj5rIdSPP47bd2) | [✅](http://confcodeofconduct.com/) |
+| [Universal JS Day](https://2018.universaljsday.com/) | Ferrara, Italy 🇮🇹 | April 13 | JavaScript | [✅](https://2018.universaljsday.com/#cfp) | ❓ |
+| [UX + DEV Summit](https://uxdsummit.com/) | Fort Lauderdale, USA 🇺🇸 | April 14-16 | Frontend, UX | ✅ | [✅](https://uxdsummit.com/call-for-speakers/) |
+| [Bulgaria Web Summit](https://bulgariawebsummit.com/) | Sofia, Bulgaria 🇧🇬 | April 14 | HTML, CSS, JavaScript | ❓ | [✅](https://bulgariawebsummit.com/) |
+| [Smashing Conf San Francisco](https://smashingconf.com/sf-2018/) | San Francisco, USA 🇺🇸 | April 17-18 | Frontend, Web, HTML, CSS, JavaScript | ❌ | [✅](https://smashingconf.com/codeofconduct) |
+| [ng-conf](https://www.ng-conf.org/) | Salt Lake City, USA 🇺🇸 | April 18-20 | JavaScript, AngularJS | [✅](https://goo.gl/forms/ExEPOnDxRRaQtC9C3) | [✅](https://www.ng-conf.org/wp-content/uploads/2017/03/Code-of-Conduct.pdf) |
+| [JSHeroes](https://jsheroes.io/) | Cluj Napoca, Romania 🇷🇴 | April 18-20 | JavaScript | [✅](https://docs.google.com/forms/d/e/1FAIpQLSdPSo4Zy_M78PHRVFz90v1_SV3IqRcyhvgK2oCDY6ju6NDWeA/viewform) | [✅](https://jsheroes.io/code-of-conduct) |
+| [DevExperience](http://devexperience.ro/) | Iasi, Romania 🇷🇴 | April 19-21 | Development, Architecture | ❌ | ❓ |
+| [React Finland](https://react-finland.fi/) | Helsinki, Finland 🇫🇮 | April 24-26 | Development, JavaScript, React, Web | ❌ | [✅](http://berlincodeofconduct.org/) |
+| [FEDC](http://frontenddesignconference.com/) | St. Petersburg, USA 🇺🇸 | April 25-27 | UX, Web, Frontend | ❌ | ❓ |
+| [#devone](https://devone.at/) | Linz, Austria 🇦🇹 | April 26 | Development, Architecture, DevOps | ❌ | [✅](https://devone.at/code-of-conduct/) |
+| [UphillConf](http://uphillconf.com/) | Bern, Switzerland 🇨🇭 | April 26-27 | Frontend, JavaScript | ❌ | [✅](https://uphillconf.com/code-of-conduct/) |
 
 ## May
 
 | Event | Location | Date | Topic | CFP | CoC |
 |-------|:--------:|:----:|:-----:|:---:|-----|
-| [Codeland](http://codelandconf.com/) | New York 🇺🇸 | May 4-5 | Development, Newcomers | [✅](http://codelandconf.com/#cfp) | [✅](http://codelandconf.com/coc/) |
-| [beyond tellerrand // Düsseldorf 2018](https://beyondtellerrand.com/) | Düsseldorf 🇩🇪 | May 7-9 |  Frontend, UX, Creativity | ❌ | [✅](https://beyondtellerrand.com/code-of-conduct) |
-| [NDC Minnesota](https://ndcminnesota.com/) | Minnesota 🇺🇸 | May 7-10 | Development, Architecture | [✅](https://ndcminnesota.com/page/call-for-papers/) | [✅](https://ndcminnesota.com/page/code-of-conduct) |
-| [Codemotion](https://codemotionworld.com/) | Amsterdam 🇳🇱 | May 8-9 | Development, Architecture | [✅](http://speaker.codemotionworld.com/c4p.php) | [✅](https://codemotionworld.com/code-of-conduct/) |
-| [JSDay Italy](https://2018.jsday.it/) | Verona 🇮🇹 | May 9-10 | JavaScript | [✅](https://cfp.jsday.it/) | [✅](https://2018.jsday.it/coc.html) |
-| [Devoxx UK](https://www.devoxx.co.uk/) | London 🇬🇧  | May 9-11 | Development, Architecture | [✅](https://cfp.devoxx.co.uk/) | ❓ |
-| [DeltaV Conference](https://2018.deltavconf.com/) | London 🇬🇧  | May 10-11 | Web, Performance | ❓ | [✅](https://2018.deltavconf.com/code-of-conduct) |
-| [React Europe](https://www.react-europe.org/) | Paris 🇫🇷 | May 17-18 | JavaScript, React | [✅](https://checkout.eventlama.com/#/events/reacteurope-2018/cfp) | [✅](http://confcodeofconduct.com/) |
-| [JSDayES](http://2018.jsday.es/) | Madrid 🇪🇸 | May 19 | JavaScript | ❓ | [✅](http://2018.jsday.es/code-of-conduct-en.html) |
-| [Holy JS](https://holyjs-piter.ru/en/) | St.Petersburg 🇷🇺 | May 19-20 | JavaScript | [✅](https://holyjs-piter.ru/en/callforpapers/) | [✅](https://holyjs-piter.ru/en/codeofconduct/) |
-| [YGLF](http://yglf.com.ua/) | Kyiv 🇺🇦 | May 24-25 | JavaScript, HTML, CSS | ✅ | [✅](http://yglf.com.ua/code-of-conduct) |
-| [Front Trends](https://2018.front-trends.com/) | Warsaw 🇵🇱 | May 24-25 | JavaScript, HTML, CSS | [✅](https://2018.front-trends.com/speaking-at-front-trends/) | [✅](https://2018.front-trends.com/code-of-conduct/) |
-| [DevSum18](http://www.devsum.se/) | Stockholm 🇸🇪 | May 31 - June 1 | Development, Architecture | [✅](http://www.devsum.se/cfp/) | [✅](http://www.devsum.se/code-of-conduct/) |
-| [Frontend United](http://frontendunited.org/) | Utrecht 🇳🇱 | May 31 - June 2 | JavaScript, HTML, CSS, Drupal | ❌ | [✅](http://2016.frontendunited.org/code-of-conduct) |
+| [Codeland](http://codelandconf.com/) | New York, USA 🇺🇸 | May 4-5 | Development, Newcomers | [✅](http://codelandconf.com/#cfp) | [✅](http://codelandconf.com/coc/) |
+| [beyond tellerrand // Düsseldorf 2018](https://beyondtellerrand.com/) | Düsseldorf, Germany 🇩🇪  | May 7-9 |  Frontend, UX, Creativity | ❌ | [✅](https://beyondtellerrand.com/code-of-conduct) |
+| [NDC Minnesota](https://ndcminnesota.com/) | Minnesota, USA 🇺🇸 | May 7-10 | Development, Architecture | [✅](https://ndcminnesota.com/page/call-for-papers/) | [✅](https://ndcminnesota.com/page/code-of-conduct) |
+| [Codemotion](https://codemotionworld.com/) | Amsterdam, The Netherlands 🇳🇱 | May 8-9 | Development, Architecture | [✅](http://speaker.codemotionworld.com/c4p.php) | [✅](https://codemotionworld.com/code-of-conduct/) |
+| [JSDay Italy](https://2018.jsday.it/) | Verona, Italy 🇮🇹 | May 9-10 | JavaScript | [✅](https://cfp.jsday.it/) | [✅](https://2018.jsday.it/coc.html) |
+| [Devoxx UK](https://www.devoxx.co.uk/) | London, UK 🇬🇧  | May 9-11 | Development, Architecture | [✅](https://cfp.devoxx.co.uk/) | ❓ |
+| [DeltaV Conference](https://2018.deltavconf.com/) | London, UK 🇬🇧  | May 10-11 | Web, Performance | ❓ | [✅](https://2018.deltavconf.com/code-of-conduct) |
+| [React Europe](https://www.react-europe.org/) | Paris, France 🇫🇷 | May 17-18 | JavaScript, React | [✅](https://checkout.eventlama.com/#/events/reacteurope-2018/cfp) | [✅](http://confcodeofconduct.com/) |
+| [JSDayES](http://2018.jsday.es/) | Madrid, Spain 🇪🇸   | May 19 | JavaScript | ❓ | [✅](http://2018.jsday.es/code-of-conduct-en.html) |
+| [Holy JS](https://holyjs-piter.ru/en/) | St.Petersburg, Russia 🇷🇺 | May 19-20 | JavaScript | [✅](https://holyjs-piter.ru/en/callforpapers/) | [✅](https://holyjs-piter.ru/en/codeofconduct/) |
+| [YGLF](http://yglf.com.ua/) | Kyiv, Ukraine 🇺🇦 | May 24-25 | JavaScript, HTML, CSS | ✅ | [✅](http://yglf.com.ua/code-of-conduct) |
+| [Front Trends](https://2018.front-trends.com/) | Warsaw, Poland 🇵🇱 | May 24-25 | JavaScript, HTML, CSS | [✅](https://2018.front-trends.com/speaking-at-front-trends/) | [✅](https://2018.front-trends.com/code-of-conduct/) |
+| [DevSum18](http://www.devsum.se/) | Stockholm, Sweden 🇸🇪 | May 31 - June 1 | Development, Architecture | [✅](http://www.devsum.se/cfp/) | [✅](http://www.devsum.se/code-of-conduct/) |
+| [Frontend United](http://frontendunited.org/) | Utrecht, The Netherlands 🇳🇱 | May 31 - June 2 | JavaScript, HTML, CSS, Drupal | ❌ | [✅](http://2016.frontendunited.org/code-of-conduct) |
 
 ## June
 
 | Event | Location | Date | Topic | CFP | CoC |
 |-------|:--------:|:----:|:-----:|:---:|-----|
-| [Syntax Conf](https://2018.syntaxcon.com) | Charlston 🇺🇸 | June 1-2 | JavaScript | ❓ | [✅](https://2018.syntaxcon.com/about/code-of-conduct/) |
-| [Building IoT](https://www.buildingiot.de) | Cologne 🇩🇪 | June 1-2 | JavaScript | [✅](https://www.buildingiot.de/call.php) | [✅](https://www.buildingiot.de/konferenz_coc.php) |
-| [CSSconf EU](https://2018.cssconf.eu) | Berlin 🇩🇪 | June 1 | CSS | [✅](https://2018.cssconf.eu/call-for-speakers/) | [✅](https://2018.cssconf.eu/code-of-conduct/) |
-| [JSConf EU](https://2018.jsconf.eu/) | Berlin 🇩🇪 | June 2-3 | JavaScript | [✅](https://2018.jsconf.eu/call-for-speakers/) | [✅](https://2018.jsconf.eu/code-of-conduct/) |
-| [Web Rebels](https://www.webrebels.org/) | Oslo 🇳🇴 | June 4-5 | Web, CSS, JavaScript | ❓ | [✅](http://jsconf.com/codeofconduct.html) |
+| [Syntax Conf](https://2018.syntaxcon.com) | Charlston, USA 🇺🇸 | June 1-2 | JavaScript | ❓ | [✅](https://2018.syntaxcon.com/about/code-of-conduct/) |
+| [Building IoT](https://www.buildingiot.de) | Cologne, Germany 🇩🇪  | June 1-2 | JavaScript | [✅](https://www.buildingiot.de/call.php) | [✅](https://www.buildingiot.de/konferenz_coc.php) |
+| [CSSconf EU](https://2018.cssconf.eu) | Berlin, Germany 🇩🇪  | June 1 | CSS | [✅](https://2018.cssconf.eu/call-for-speakers/) | [✅](https://2018.cssconf.eu/code-of-conduct/) |
+| [JSConf EU](https://2018.jsconf.eu/) | Berlin, Germany 🇩🇪  | June 2-3 | JavaScript | [✅](https://2018.jsconf.eu/call-for-speakers/) | [✅](https://2018.jsconf.eu/code-of-conduct/) |
+| [Web Rebels](https://www.webrebels.org/) | Oslo, Norway 🇳🇴 | June 4-5 | Web, CSS, JavaScript | ❓ | [✅](http://jsconf.com/codeofconduct.html) |
 | [Webconf.asia 2018](https://webconf.asia/) | Hong Kong 🇭🇰 | June 6-9 | Web | ❓ | [✅](https://webconf.asia/code-of-conduct) |
-| [pitercss_conf](https://pitercss.com/) | St. Petersburg 🇷🇺 | June 8-9 | HTML, CSS, SVG, JavaScript, Typography | ❓ | ❓ |
-| [DevIT](http://devitconf.org/) | Thessaloniki  🇬🇷 | June 9 | JavaScript | ❓ | [✅](http://devitconf.org/code-of-conduct) |
-| [Fluent](https://conferences.oreilly.com/fluent/fl-ca/) | San Jose 🇺🇸 | June 11-14 | JavaScript, Performance, Web | [✅](https://conferences.oreilly.com/fluent/fl-ca/public/cfp/606) | [✅](http://www.oreilly.com/conferences/code-of-conduct.html) |
-| [ConvergeSE](http://convergese.com/) | Columbia 🇺🇸 | June 13-15 | Development, Web | ❓ | ❓ |
-| [NDC Oslo](https://ndcoslo.com/) | Oslo 🇳🇴 | June 11-15 | Development, Architecture| [✅](https://ndcoslo.com/page/call-for-papers/) | [✅](https://ndcoslo.com/page/code-of-conduct) |
-| [CSS Day](https://cssday.nl/2018) | Amsterdam 🇳🇱 | June 14-15 | CSS, UX | ❌ | [✅](https://cssday.nl/2018/contact#code-of-conduct) |
-| [EnterJS](http://www.enterjs.de/) | Darmstadt 🇩🇪 | June 19-21 | JavaScript | [✅](https://www.enterjs.de/call-for-proposals-en) | [✅](https://www.enterjs.de/diversity#code-of-conduct-english) |
-| [Smashing Conf Toronto](https://smashingconf.com/toronto-2018/) | Toronto 🇨🇦 | June 26-27 | Frontend, Web, HTML, CSS, JavaScript | ❌ | [✅](https://smashingconf.com/codeofconduct) |
+| [pitercss_conf](https://pitercss.com/) | St. Petersburg, Russia 🇷🇺 | June 8-9 | HTML, CSS, SVG, JavaScript, Typography | ❓ | ❓ |
+| [DevIT](http://devitconf.org/) | Thessaloniki , Greece 🇬🇷 | June 9 | JavaScript | ❓ | [✅](http://devitconf.org/code-of-conduct) |
+| [Fluent](https://conferences.oreilly.com/fluent/fl-ca/) | San Jose, USA 🇺🇸 | June 11-14 | JavaScript, Performance, Web | [✅](https://conferences.oreilly.com/fluent/fl-ca/public/cfp/606) | [✅](http://www.oreilly.com/conferences/code-of-conduct.html) |
+| [ConvergeSE](http://convergese.com/) | Columbia, USA 🇺🇸 | June 13-15 | Development, Web | ❓ | ❓ |
+| [NDC Oslo](https://ndcoslo.com/) | Oslo, Norway 🇳🇴 | June 11-15 | Development, Architecture| [✅](https://ndcoslo.com/page/call-for-papers/) | [✅](https://ndcoslo.com/page/code-of-conduct) |
+| [CSS Day](https://cssday.nl/2018) | Amsterdam, The Netherlands 🇳🇱 | June 14-15 | CSS, UX | ❌ | [✅](https://cssday.nl/2018/contact#code-of-conduct) |
+| [EnterJS](http://www.enterjs.de/) | Darmstadt, Germany 🇩🇪  | June 19-21 | JavaScript | [✅](https://www.enterjs.de/call-for-proposals-en) | [✅](https://www.enterjs.de/diversity#code-of-conduct-english) |
+| [Smashing Conf Toronto](https://smashingconf.com/toronto-2018/) | Toronto, Canada 🇨🇦 | June 26-27 | Frontend, Web, HTML, CSS, JavaScript | ❌ | [✅](https://smashingconf.com/codeofconduct) |
 
 ## July
 
 | Event | Location | Date | Topic | CFP | CoC |
 |-------|:--------:|:----:|:-----:|:---:|-----|
-| [Fullstack 2018](https://skillsmatter.com/conferences/9815-fullstack-2018-the-conference-on-javascript-node-and-internet-of-things#program) | London 🇬🇧  | July 11-13 | JavaScript, CSS, HTML, Web | [✅](https://skillsmatter.com/conferences/9815-fullstack-2018-the-conference-on-javascript-node-and-internet-of-things#get_involved) | [✅](https://skillsmatter.com/go/code-of-conduct) |
-| [Curry On Conf](http://curry-on.org/) | Amsterdam 🇳🇱 | July 16 | Development, Architecture | ❓ | [✅](http://curry-on.org/2017/code-of-conduct.html) |
-| [ScotlandCSS](http://scotlandcss.com/) | Edinburgh 🇬🇧  | July 18 | CSS | [✅](https://www.papercall.io/scotlandcss-2018) | [✅](http://scotlandcss.com/codeofconduct/) |
-| [ScotlandJS](http://scotlandjs.com/) | Edinburgh 🇬🇧  | July 19-20 | JavaScript | [✅](https://www.papercall.io/scotlandjs-2018) | [✅](http://scotlandjs.com/codeofconduct/) |
-| [NodeSummit](http://www.nodesummit.com) | San Francisco 🇺🇸 | July 23-25 | JavaScript, Node.js | [✅](http://www.nodesummit.com/speakers/become-a-speaker/) | [✅](http://www.nodesummit.com/node-summit-code-of-conduct/) |
+| [Fullstack 2018](https://skillsmatter.com/conferences/9815-fullstack-2018-the-conference-on-javascript-node-and-internet-of-things#program) | London, UK 🇬🇧  | July 11-13 | JavaScript, CSS, HTML, Web | [✅](https://skillsmatter.com/conferences/9815-fullstack-2018-the-conference-on-javascript-node-and-internet-of-things#get_involved) | [✅](https://skillsmatter.com/go/code-of-conduct) |
+| [Curry On Conf](http://curry-on.org/) | Amsterdam, The Netherlands 🇳🇱 | July 16 | Development, Architecture | ❓ | [✅](http://curry-on.org/2017/code-of-conduct.html) |
+| [ScotlandCSS](http://scotlandcss.com/) | Edinburgh, UK 🇬🇧  | July 18 | CSS | [✅](https://www.papercall.io/scotlandcss-2018) | [✅](http://scotlandcss.com/codeofconduct/) |
+| [ScotlandJS](http://scotlandjs.com/) | Edinburgh, UK 🇬🇧  | July 19-20 | JavaScript | [✅](https://www.papercall.io/scotlandjs-2018) | [✅](http://scotlandjs.com/codeofconduct/) |
+| [NodeSummit](http://www.nodesummit.com) | San Francisco, USA 🇺🇸 | July 23-25 | JavaScript, Node.js | [✅](http://www.nodesummit.com/speakers/become-a-speaker/) | [✅](http://www.nodesummit.com/node-summit-code-of-conduct/) |
 
 ## August
 
 | Event | Location | Date | Topic | CFP | CoC |
 |-------|:--------:|:----:|:-----:|:---:|-----|
-| [React Rally](http://www.reactrally.com/) | Salt Lake City 🇺🇸 | August 16-17 | JavaScript, React | ❓ | [✅](http://www.reactrally.com/conduct) |
-| [Form & Function Class 9](http://2018.formfunctionclass.com/) | Manila 🇵🇭 | August 18 | Design, UX , Frontend, Web | ❌  | ❓ |
+| [React Rally](http://www.reactrally.com/) | Salt Lake City, USA 🇺🇸 | August 16-17 | JavaScript, React | ❓ | [✅](http://www.reactrally.com/conduct) |
+| [Form & Function Class 9](http://2018.formfunctionclass.com/) | Manila, Philippines 🇵🇭 | August 18 | Design, UX , Frontend, Web | ❌  | ❓ |
 
 ## September
 
 | Event | Location | Date | Topic | CFP | CoC |
 |-------|:--------:|:----:|:-----:|:---:|-----|
-| [Webkongress Erlangen](https://www.webkongress.fau.de/) | Erlangen 🇩🇪 | September 11-13 | Web, JavaScript, HTML, CSS | [✅](https://www.webkongress.fau.de/call-for-paper/) | ❓ |
-| [JSFoo](https://jsfoo.in/) | Bangalore 🇮🇳 | September 15-16 | Web, JavaScript, Design, Ux | [✅](https://jsfoo.talkfunnel.com/2018/) | [✅](https://jsfoo.in/code-of-conduct/) |
-| [WebExpo](https://www.webexpo.net/) | Prague 🇨🇿 | September 21-22 | Web, JavaScript, Design, Ux | ❌  | [✅](http://confcodeofconduct.com/) |
+| [Webkongress Erlangen](https://www.webkongress.fau.de/) | Erlangen, Germany 🇩🇪  | September 11-13 | Web, JavaScript, HTML, CSS | [✅](https://www.webkongress.fau.de/call-for-paper/) | ❓ |
+| [JSFoo](https://jsfoo.in/) | Bangalore, India 🇮🇳 | September 15-16 | Web, JavaScript, Design, Ux | [✅](https://jsfoo.talkfunnel.com/2018/) | [✅](https://jsfoo.in/code-of-conduct/) |
+| [WebExpo](https://www.webexpo.net/) | Prague, Czech Republic 🇨🇿 | September 21-22 | Web, JavaScript, Design, Ux | ❌  | [✅](http://confcodeofconduct.com/) |
 
 ## October
 
 | Event | Location | Date | Topic | CFP | CoC |
 |-------|:--------:|:----:|:-----:|:---:|-----|
-| [Technorama](https://techorama.nl/) | Ede 🇳🇱 | October 1-3 | Development, Architecture | ✅ | ❓ |
-| [JS Interactive](http://events.linuxfoundation.org/events/js-interactive) | Vancouver 🇨🇦 | October 10-12 | JavaScript | [✅](https://linuxfoundation.smapply.io/prog/lst/) | [✅](http://events.linuxfoundation.org/content/code-conduct-4) |
+| [Technorama](https://techorama.nl/) | Ede, The Netherlands 🇳🇱 | October 1-3 | Development, Architecture | ✅ | ❓ |
+| [JS Interactive](http://events.linuxfoundation.org/events/js-interactive) | Vancouver, Canada 🇨🇦 | October 10-12 | JavaScript | [✅](https://linuxfoundation.smapply.io/prog/lst/) | [✅](http://events.linuxfoundation.org/content/code-conduct-4) |
 
 ## November
 
 | Event | Location | Date | Topic | CFP | CoC |
 |-------|:--------:|:----:|:-----:|:---:|-----|
-| [BRING IT TOGETHER](http://bringittogether.ca/) | Niagara Falls 🇨🇦 | November 8-10 | Web, Education | ❌  | [✅](http://bringittogether.ca/anti-harassement-statement-declaration-contre-lharcelement/) |
+| [BRING IT TOGETHER](http://bringittogether.ca/) | Niagara Falls, Canada 🇨🇦 | November 8-10 | Web, Education | ❌  | [✅](http://bringittogether.ca/anti-harassement-statement-declaration-contre-lharcelement/) |
 
 ## December
 


### PR DESCRIPTION
I noticed that all the countries are marked with Unicode flags. This looks lovely, but isn't searchable by keyboard, and if you don't know the flags of a country, isn't highly readable. 

This PR will add all the names of the country alongside the flag. 